### PR TITLE
remove no_draw + discrete constrained params

### DIFF
--- a/models/discrete.py
+++ b/models/discrete.py
@@ -8,8 +8,10 @@ from scipy.optimize import minimize
 from filtering import get_basic_filter
 from smoothing import times_and_skills_by_player_to_by_match
 
-# skills.shape = (number of players, number of particles)
+# skills.shape = (number of players, size of discrete skill space)
 # match_result in (0 for draw, 1 for p1 victory, 2 for p2 victory)
+# state_initial_params = (initial_distribution,)
+#       initial_distribution = full distribution of unseen player
 # static_propagate_params = (tau,)
 #       tau = rate of dynamics
 # static_update_params = (s, epsilon)
@@ -148,6 +150,8 @@ def maximiser(times_by_player: Sequence,
               i: int,
               random_key: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
 
+    no_draw_bool = (update_params[1] == 0.) and (0 not in match_results)
+
     n_players = len(smoother_skills_and_extras_by_player)
 
     smoothing_list = [smoother_skills_and_extras_by_player[i][0] for i in range(n_players)]
@@ -155,11 +159,11 @@ def maximiser(times_by_player: Sequence,
 
     maxed_initial_params = jnp.array([smoothing_list[i][0] for i in range(n_players)]).mean(0)
 
-    skills = maxed_initial_params.shape[0]
+    m = maxed_initial_params.shape[0]
 
-    def negative_expected_log_propagate(tau):
-
-        K_delta_t = CTMC_kernel_reflected(skills, tau)
+    def negative_expected_log_propagate(log_tau):
+        tau = jnp.exp(log_tau)
+        K_delta_t = CTMC_kernel_reflected(m, tau)
         value_negative_expected_log_propagate = 0
         for ind in range(n_players):
             diff_time = (times_by_player[ind][1:] - times_by_player[ind][:-1])
@@ -171,30 +175,38 @@ def maximiser(times_by_player: Sequence,
 
         return value_negative_expected_log_propagate
 
-    optim_res = minimize(negative_expected_log_propagate, propagate_params, method='cobyla')
+    optim_res = minimize(negative_expected_log_propagate, jnp.log(propagate_params), method='cobyla')
     assert optim_res.success, 'epsilon optimisation failed'
-    maxed_tau = optim_res.x[0]
+    maxed_tau = jnp.exp(optim_res.x[0])
 
-    def negative_expected_log_obs_dens(epsilon):
-        Phi = Phi_emission(update_params[0], epsilon, skills)
+    if no_draw_bool:
+        maxed_s_and_epsilon = update_params
+    else:
+        smoother_skills_by_player = [ss for ss, _ in smoother_skills_and_extras_by_player]
 
-        value_negative_expected_log_update = 0
-        for t in range(len(match_results)):
-            joint_players = jnp.reshape(smoothing_list[match_player_indices_seq[t, 0]][t],
-                                        (skills, 1))\
-                            * jnp.reshape(smoothing_list[match_player_indices_seq[t, 1]][t], (1, skills))
-            current_Phi = Phi[:, :, match_results[t]]
+        match_times, match_skills_p1, match_skills_p2 = times_and_skills_by_player_to_by_match(times_by_player,
+                                                                                               smoother_skills_by_player,
+                                                                                               match_player_indices_seq)
 
-            value_negative_expected_log_update -= jnp.sum(jnp.log(1e-20 + current_Phi
-                                                                  + jnp.array(joint_players == 0, jnp.float32))
-                                                          * joint_players)
+        def negative_expected_log_obs_dens(log_epsilon):
+            epsilon = jnp.exp(log_epsilon)
+            Phi = Phi_emission(update_params[0], epsilon, m)
 
-        return value_negative_expected_log_update
+            value_negative_expected_log_update = 0
+            for t in range(len(match_results)):
+                joint_players = jnp.reshape(match_skills_p1[t], (m, 1)) * jnp.reshape(match_skills_p2[t], (1, m))
+                current_Phi = Phi[:, :, match_results[t]]
 
-    optim_res = minimize(negative_expected_log_obs_dens, update_params[1], method='cobyla')
+                value_negative_expected_log_update -= jnp.sum(jnp.log(1e-20 + current_Phi
+                                                                      + jnp.array(joint_players == 0, jnp.float32))
+                                                              * joint_players)
 
-    assert optim_res.success, 'epsilon optimisation failed'
-    maxed_epsilon = optim_res.x[0]
-    maxed_s_and_epsilon = update_params.at[1].set(maxed_epsilon)
+            return value_negative_expected_log_update
+
+        optim_res = minimize(negative_expected_log_obs_dens, jnp.log(update_params[1]), method='cobyla')
+
+        assert optim_res.success, 'epsilon optimisation failed'
+        maxed_epsilon = jnp.exp(optim_res.x[0])
+        maxed_s_and_epsilon = update_params.at[1].set(maxed_epsilon)
 
     return maxed_initial_params, maxed_tau, maxed_s_and_epsilon

--- a/simulate_and_em.py
+++ b/simulate_and_em.py
@@ -6,8 +6,8 @@ from smoothing import expectation_maximisation
 
 rk = random.PRNGKey(0)
 
-n_players = 50
-n_matches = 1000
+n_players = 20
+n_matches = 130
 
 init_mean = 0.
 init_var = 3.
@@ -66,35 +66,52 @@ em_init_s_and_epsilon = jnp.array([s, epsilon / 2])
 # em_init_tau = tau
 # em_init_s_and_epsilon = jnp.array([s, epsilon])
 
+#
+# # TrueSkill (EP)
+# initial_params_ep, propagate_params_ep, update_params_ep = expectation_maximisation(models.trueskill.initiator,
+#                                                                                     models.trueskill.filter,
+#                                                                                     models.trueskill.smoother,
+#                                                                                     models.trueskill.maximiser,
+#                                                                                     em_init_mean_and_var,
+#                                                                                     em_init_tau,
+#                                                                                     em_init_s_and_epsilon,
+#                                                                                     match_times,
+#                                                                                     match_indices_seq,
+#                                                                                     sim_results,
+#                                                                                     n_em_steps,
+#                                                                                     n_players=n_players)
+#
+# # TrueSkill (SMC)
+# models.lsmc.n_particles = 1000
+# initial_params_smc, propagate_params_smc, update_params_smc = expectation_maximisation(models.lsmc.initiator,
+#                                                                                        models.lsmc.filter,
+#                                                                                        models.lsmc.smoother,
+#                                                                                        models.lsmc.maximiser,
+#                                                                                        em_init_mean_and_var,
+#                                                                                        em_init_tau,
+#                                                                                        em_init_s_and_epsilon,
+#                                                                                        match_times,
+#                                                                                        match_indices_seq,
+#                                                                                        sim_results,
+#                                                                                        n_em_steps,
+#                                                                                        n_players=n_players)
 
-# TrueSkill (EP)
-initial_params_ep, propagate_params_ep, update_params_ep = expectation_maximisation(models.trueskill.initiator,
-                                                                                    models.trueskill.filter,
-                                                                                    models.trueskill.smoother,
-                                                                                    models.trueskill.maximiser,
-                                                                                    em_init_mean_and_var,
-                                                                                    em_init_tau,
-                                                                                    em_init_s_and_epsilon,
-                                                                                    match_times,
-                                                                                    match_indices_seq,
-                                                                                    sim_results,
-                                                                                    n_em_steps,
-                                                                                    n_players=n_players)
-
-# TrueSkill (SMC)
-models.lsmc.n_particles = 1000
-initial_params_smc, propagate_params_smc, update_params_smc = expectation_maximisation(models.lsmc.initiator,
-                                                                                       models.lsmc.filter,
-                                                                                       models.lsmc.smoother,
-                                                                                       models.lsmc.maximiser,
-                                                                                       em_init_mean_and_var,
-                                                                                       em_init_tau,
-                                                                                       em_init_s_and_epsilon,
-                                                                                       match_times,
-                                                                                       match_indices_seq,
-                                                                                       sim_results,
-                                                                                       n_em_steps,
-                                                                                       n_players=n_players)
+# Discrete
+discrete_m = 100
+em_init_dist = jnp.ones(discrete_m) / discrete_m
+initial_params_discrete, propagate_params_discrete, update_params_discrete \
+    = expectation_maximisation(models.discrete.initiator,
+                               models.discrete.filter,
+                               models.discrete.smoother,
+                               models.discrete.maximiser,
+                               em_init_dist,
+                               em_init_tau,
+                               em_init_s_and_epsilon,
+                               match_times,
+                               match_indices_seq,
+                               sim_results,
+                               n_em_steps,
+                               n_players=n_players)
 
 fig, axes = plt.subplots(3, figsize=(5, 10))
 

--- a/simulate_and_em_nodraw.py
+++ b/simulate_and_em_nodraw.py
@@ -6,8 +6,8 @@ from smoothing import expectation_maximisation
 
 rk = random.PRNGKey(0)
 
-n_players = 50
-n_matches = 1000
+n_players = 20
+n_matches = 130
 
 init_mean = 0.
 init_var = 3.
@@ -16,7 +16,6 @@ s = 1.
 epsilon = 0.
 
 n_em_steps = 20
-
 
 # init_var_inv_prior_var = 0.01
 # tau2_inv_prior_var = 0.01
@@ -63,13 +62,11 @@ em_init_tau = tau * 2
 
 em_init_s_and_epsilon = jnp.array([s, epsilon])
 
-
-
 # TrueSkill (EP)
 initial_params_ep, propagate_params_ep, update_params_ep = expectation_maximisation(models.trueskill.initiator,
                                                                                     models.trueskill.filter,
                                                                                     models.trueskill.smoother,
-                                                                                    models.trueskill.maximiser_no_draw,
+                                                                                    models.trueskill.maximiser,
                                                                                     em_init_mean_and_var,
                                                                                     em_init_tau,
                                                                                     em_init_s_and_epsilon,
@@ -84,7 +81,7 @@ models.lsmc.n_particles = 1000
 initial_params_smc, propagate_params_smc, update_params_smc = expectation_maximisation(models.lsmc.initiator,
                                                                                        models.lsmc.filter,
                                                                                        models.lsmc.smoother,
-                                                                                       models.lsmc.maximiser_no_draw,
+                                                                                       models.lsmc.maximiser,
                                                                                        em_init_mean_and_var,
                                                                                        em_init_tau,
                                                                                        em_init_s_and_epsilon,
@@ -93,6 +90,24 @@ initial_params_smc, propagate_params_smc, update_params_smc = expectation_maximi
                                                                                        sim_results,
                                                                                        n_em_steps,
                                                                                        n_players=n_players)
+
+
+# Discrete
+discrete_m = 100
+em_init_dist = jnp.ones(discrete_m) / discrete_m
+initial_params_discrete, propagate_params_discrete, update_params_discrete \
+    = expectation_maximisation(models.discrete.initiator,
+                               models.discrete.filter,
+                               models.discrete.smoother,
+                               models.discrete.maximiser,
+                               em_init_dist,
+                               em_init_tau,
+                               em_init_s_and_epsilon,
+                               match_times,
+                               match_indices_seq,
+                               sim_results,
+                               n_em_steps,
+                               n_players=n_players)
 
 fig, axes = plt.subplots(2, figsize=(5, 10))
 


### PR DESCRIPTION
Removed `maximiser_no_draw` from `lsmc` and `trueskill` - instead if given `epsilon=0` and no draws in data it will know not to try and maximise the epsilon parameter (since it would be maximal at 0 anyway)


Updated discrete `maximiser` to maximise in log space so that parameters are automatically constrained to be positive