### PR TITLE
Slight refactor of discrete

### DIFF
--- a/models/discrete.py
+++ b/models/discrete.py
@@ -200,23 +200,13 @@ def maximiser(times_by_player: Sequence,
 
 
 def simulate(init_player_times: jnp.ndarray,
-             initial_distribution_skills_player: jnp.ndarray,  # log_initial_distribution_skills: jnp.ndarray,
+             init_player_skills: jnp.ndarray,
              match_times: jnp.ndarray,
              match_player_indices_seq: jnp.ndarray,
              tau: float,
              s_and_epsilon: Union[jnp.ndarray, Sequence],
-             start_random_key: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+             random_key: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
     s, epsilon = s_and_epsilon
-
-    n_players = initial_distribution_skills_player.shape[0]
-    initial_distribution_skills_player *= jnp.ones((n_players, M))
-
-    init_skill_key, random_key = random.split(start_random_key, 2)
-
-    # init_player_skills = random.categorical(init_skill_key, log_initial_distribution_skills, axis =1)
-    init_player_skills \
-        = vmap(lambda rk, dist: random.choice(rk, a=jnp.arange(M), p=dist)) \
-        (random.split(init_skill_key, n_players), initial_distribution_skills_player)
 
     Phi = Phi_emission(s, epsilon)
 


### PR DESCRIPTION
- Changed discrete.simulate to take the already sampled `init_player_skills` as input. Perhaps it is better to have the initial skills sampled within simulate rather than explicitly given. trueskill.simulate also takes the exact skills as input rather than sampling them, so if needed we can change both later.

- Shrunk the `K_t` functions down to just the one function rather than a function generator

- Added some commented code to do the operations with matrix multiplication rather than einsum, this might be easier to read? (Although I think the psi matrix we generate is the transpose of the one in the paper draft but this is quite possibly an error in the paper rather than the code.